### PR TITLE
BAU: Add timestamp to versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,10 @@
 attrs==21.2.0
+freezegun==1.1.0
 iniconfig==1.1.1
 packaging==21.0
 pluggy==0.13.1
 py==1.10.0
+python-dateutil==2.8.2
 pyparsing==2.4.7
 pytest==6.2.4
 requests-mock==1.9.3

--- a/src/lib/check_script.py
+++ b/src/lib/check_script.py
@@ -2,18 +2,29 @@
 
 import json
 import sys
+import time
 
-from .utils import call_github_api, get_hash_of_members, validate_source
+from .utils import call_github_api, get_hash_of_members, members_hash_from_version, validate_source
 
 
 def main():
     input_json = json.loads(sys.stdin.read())
     source = input_json.get("source")
+    version = input_json.get("version")
 
     validate_source(source)
     response = call_github_api(source)
+    members_hash = get_hash_of_members(response)
 
-    print(f'[{{"hash": "{get_hash_of_members(response)}"}}]')
+    if not version or members_hash != members_hash_from_version(version):
+        print(f'[{{"hash": "{suffix_timestamp(members_hash)}"}}]')
+    else:
+        print(f'[{{"hash": "{version.get("hash")}"}}]')
+
+
+def suffix_timestamp(hash):
+    return f"{hash}-{int(time.time())}"
+
 
 
 if __name__ == '__main__':

--- a/src/lib/in_script.py
+++ b/src/lib/in_script.py
@@ -3,13 +3,13 @@
 import json
 import sys
 
-from .utils import call_github_api, eprint, get_hash_of_members, validate_source
+from .utils import call_github_api, eprint, get_hash_of_members, members_hash_from_version, validate_source
 
 
 def main():
     input_json = json.loads(sys.stdin.read())
     source = input_json.get("source")
-    requested_version = input_json.get("version").get('hash')
+    requested_version = input_json.get("version")
     destination_dir = sys.argv[1]
 
     validate_source(source)
@@ -17,10 +17,10 @@ def main():
 
     current_version = get_hash_of_members(response)
 
-    if requested_version != current_version:
+    if current_version != members_hash_from_version(requested_version):
         eprint(
-            f"[ERROR] Requested version ({requested_version[0:8]}) does not match current version ({current_version[0:8]})."
-            " The team membership was probably updated between the check and the get."
+            f"[ERROR] Requested version ({members_hash_from_version(requested_version)[0:8]}) does not match current "
+            f"version ({current_version[0:8]}). The team membership was probably updated between the check and the get."
         )
         exit(1)
 
@@ -29,7 +29,7 @@ def main():
             f.write(f"{member_login}\n")
 
     output = {
-        "version": {"hash": current_version},
+        "version": {"hash": requested_version.get("hash")},
         "metadata": [
             {"name": "organisation", "value": source['org']},
             {"name": "team", "value": source['team']},

--- a/src/lib/utils/__init__.py
+++ b/src/lib/utils/__init__.py
@@ -1,1 +1,1 @@
-from .util import call_github_api, eprint, get_hash_of_members, validate_source
+from .util import call_github_api, eprint, get_hash_of_members, members_hash_from_version, validate_source

--- a/src/lib/utils/util.py
+++ b/src/lib/utils/util.py
@@ -50,3 +50,7 @@ def get_hash_of_members(response):
     for member in members:
         eprint(f"    {member}")
     return hashlib.sha256(''.join(members).encode('utf-8')).hexdigest()
+
+
+def members_hash_from_version(version):
+    return version.get('hash').split('-')[0]

--- a/test/test_check_script.py
+++ b/test/test_check_script.py
@@ -3,6 +3,7 @@ import json
 import sys
 from unittest.mock import patch
 
+from freezegun import freeze_time
 import pytest
 import requests_mock
 
@@ -20,10 +21,11 @@ class TestCheckScript:
             'team': 'John'
         },
         'version': {
-            'hash': '12a14115c9b3f5027ed3b983f1b9315cdf48239d807f5c50294e95312c6ae0c1'
+            'hash': 'someinputhash'
         }
     })
 
+    @freeze_time("2020-03-08")
     @requests_mock.Mocker(kw='req_mocker')
     def test_returns_a_hash_of_the_current_membership(self, stdin_mock, **kwargs):
         stdin_mock.read.return_value = self.input_json
@@ -43,7 +45,88 @@ class TestCheckScript:
 
         sys.stdout = sys.__stdout__
 
-        assert captured_stdout.getvalue() == '[{"hash": "12a14115c9b3f5027ed3b983f1b9315cdf48239d807f5c50294e95312c6ae0c1"}]\n'
+        assert captured_stdout.getvalue() == '[{"hash": "12a14115c9b3f5027ed3b983f1b9315cdf48239d807f5c50294e95312c6ae0c1-1583625600"}]\n'
+
+    @freeze_time("1984-09-28")
+    @requests_mock.Mocker(kw='req_mocker')
+    def test_returns_a_hash_of_the_current_membership_when_no_version_supplied(self, stdin_mock, **kwargs):
+        no_version_input = json.loads(self.input_json)
+        del no_version_input['version']
+        stdin_mock.read.return_value = json.dumps(no_version_input)
+        kwargs['req_mocker'].get(
+            'https://api.github.com/orgs/Flamingo/teams/John/members',
+            json=[
+                {'login': 'Sarah'},
+                {'login': 'Duck'},
+                {'login': 'Bread Man'},
+            ]
+        )
+
+        captured_stdout = io.StringIO()
+        sys.stdout = captured_stdout
+
+        check_script.main()
+
+        sys.stdout = sys.__stdout__
+
+        assert captured_stdout.getvalue() == '[{"hash": "12a14115c9b3f5027ed3b983f1b9315cdf48239d807f5c50294e95312c6ae0c1-465177600"}]\n'
+
+    @requests_mock.Mocker(kw='req_mocker')
+    def test_returns_a_unique_version_for_previously_seen_team_membership(self, stdin_mock, **kwargs):
+        stdin_mock.read.return_value = self.input_json
+        kwargs['req_mocker'].get(
+            'https://api.github.com/orgs/Flamingo/teams/John/members',
+            [
+                {'json': []},
+                {'json': [
+                    {'login': 'Sarah'},
+                    {'login': 'Duck'},
+                    {'login': 'Bread Man'},
+                ]},
+                {'json': []},
+
+            ],
+        )
+
+        captured_stdout_1 = io.StringIO()
+        sys.stdout = captured_stdout_1
+
+        with freeze_time('1984-09-28 12:00:00'):
+            check_script.main()
+
+        version_1 = json.loads(captured_stdout_1.getvalue())[0]['hash']
+        version_2_input = json.loads(self.input_json)
+        version_2_input['version']['hash'] = version_1
+        stdin_mock.read.return_value = json.dumps(version_2_input)
+
+        captured_stdout_2 = io.StringIO()
+        sys.stdout = captured_stdout_2
+
+        with freeze_time('1984-09-28 12:05:00'):
+            check_script.main()
+
+        version_2 = json.loads(captured_stdout_2.getvalue())[0]['hash']
+        version_3_input = json.loads(self.input_json)
+        version_3_input['version']['hash'] = version_2
+        stdin_mock.read.return_value = json.dumps(version_3_input)
+
+        captured_stdout_3 = io.StringIO()
+        sys.stdout = captured_stdout_3
+
+        with freeze_time('1984-09-28 12:10:00'):
+            check_script.main()
+
+        version_3 = json.loads(captured_stdout_3.getvalue())[0]['hash']
+
+        version_1_hash_and_timestamp = self.version_components(version_1)
+        version_3_hash_and_timestamp = self.version_components(version_3)
+
+        assert version_1_hash_and_timestamp['members_hash'] == version_3_hash_and_timestamp['members_hash']
+        assert version_1_hash_and_timestamp['timestamp'] < version_3_hash_and_timestamp['timestamp']
+
+    def version_components(self, version):
+        components = version.split('-')
+        return {'members_hash': components[0], 'timestamp': components[1]}
 
     def test_exits_if_invalid_source_input(self, stdin_mock):
         for source_key in ['auth_user', 'auth_token', 'org', 'team']:

--- a/test/test_in_script.py
+++ b/test/test_in_script.py
@@ -3,6 +3,7 @@ import json
 import sys
 from unittest.mock import patch
 
+from freezegun import freeze_time
 import pytest
 import requests_mock
 
@@ -26,10 +27,11 @@ class TestInScript:
             'team': 'John'
         },
         'version': {
-            'hash': '12a14115c9b3f5027ed3b983f1b9315cdf48239d807f5c50294e95312c6ae0c1'
+            'hash': '12a14115c9b3f5027ed3b983f1b9315cdf48239d807f5c50294e95312c6ae0c1-1583625600'
         }
     })
 
+    @freeze_time("2020-03-08")
     @requests_mock.Mocker(kw='req_mocker')
     def test_returns_the_version_and_writes_members_to_file(self, stdin_mock, temp_dir, **kwargs):
         with patch.object(sys, 'argv', ['_', temp_dir]):
@@ -51,7 +53,7 @@ class TestInScript:
             sys.stdout = sys.__stdout__
 
             assert captured_stdout.getvalue() == '{' \
-                '"version": {"hash": "12a14115c9b3f5027ed3b983f1b9315cdf48239d807f5c50294e95312c6ae0c1"}, ' \
+                '"version": {"hash": "12a14115c9b3f5027ed3b983f1b9315cdf48239d807f5c50294e95312c6ae0c1-1583625600"}, ' \
                 '"metadata": [' \
                     '{"name": "organisation", "value": "Flamingo"}, ' \
                     '{"name": "team", "value": "John"}' \


### PR DESCRIPTION
Concourse will only trigger if a resource's check returns a version it
hasn't seen before.

This meant that if the GitHub team membership changed to a combination
of members previously encountered (including no members at all) this
resources wouldn't trigger.

To resolve this problem, this change appends a timestamp to the version
returned to Concourse. This means that each version is unique and the
resource will trigger on every membership change.